### PR TITLE
Playlist Cover Art

### DIFF
--- a/app/components/ListItem.tsx
+++ b/app/components/ListItem.tsx
@@ -7,7 +7,7 @@ import colors from '@app/styles/colors'
 import font from '@app/styles/font'
 import { useNavigation } from '@react-navigation/native'
 import React, { useCallback } from 'react'
-import { StyleProp, StyleSheet, Text, View, ViewStyle } from 'react-native'
+import { ImageResizeMode, StyleProp, StyleSheet, Text, View, ViewStyle } from 'react-native'
 import IconFA5 from 'react-native-vector-icons/FontAwesome5'
 import IconMat from 'react-native-vector-icons/MaterialIcons'
 import { AlbumContextPressable, ArtistContextPressable, SongContextPressable } from './ContextMenu'
@@ -56,7 +56,8 @@ const ListItem: React.FC<{
   listStyle?: 'big' | 'small'
   subtitle?: string
   style?: StyleProp<ViewStyle>
-}> = ({ item, contextId, queueId, onPress, showArt, showStar, subtitle, listStyle, style }) => {
+  CustomArt?: React.FC<{style: any, resizeMode: ImageResizeMode}> | null
+}> = ({ item, contextId, queueId, onPress, showArt, showStar, subtitle, listStyle, style, CustomArt }) => {
   const navigation = useNavigation()
   const starred = useStarred(item.id, item.itemType)
 
@@ -150,10 +151,15 @@ const ListItem: React.FC<{
   const artStyle = { ...styles.art, ...sizeStyle.art }
   const resizeMode = 'cover'
   let coverArt = <></>
-  if (item.itemType === 'artist') {
-    coverArt = <CoverArt type="artist" artistId={item.id} round={true} style={artStyle} resizeMode={resizeMode} />
-  } else {
-    coverArt = <CoverArt type="cover" coverArt={item.coverArt} style={artStyle} resizeMode={resizeMode} />
+  if(CustomArt != null) {
+    coverArt = <CustomArt style={artStyle} resizeMode={resizeMode} />;
+  }
+  else {
+    if (item.itemType === 'artist') {
+      coverArt = <CoverArt type="artist" artistId={item.id} round={true} style={artStyle} resizeMode={resizeMode} />
+    } else {
+      coverArt = <CoverArt type="cover" coverArt={item.coverArt} style={artStyle} resizeMode={resizeMode} />
+    }
   }
 
   return (

--- a/app/components/PlaylistCover.tsx
+++ b/app/components/PlaylistCover.tsx
@@ -1,0 +1,33 @@
+import { usePlaylistWithSongs } from '@app/hooks/music'
+import { PlaylistListItem, Song } from '@app/models/music'
+import CoverArt from '@app/components/CoverArt'
+import React, { useMemo } from 'react'
+import { StyleSheet, ImageResizeMode, FlatList } from 'react-native'
+
+export function usePlaylistCover2x2(_songs: Song[]) {
+  const generator: React.FC<{style: any, resizeMode: ImageResizeMode}> = ({style}) => {
+    const nestedStyle = { ...style, ...{ width: style.width / 2, height: style.height / 2, marginRight: 0 } }
+    // we need to wrap the songs in a custom object because the list will ignore null values
+    const songs = [...Array(4)].map((_, i) => ({s: i < _songs.length ? _songs[i] : null}))
+    return (
+      <FlatList
+        data={songs}
+        numColumns={2}
+        style={styles.imgGrid}
+        keyExtractor={(_, idx) => idx.toString()}
+        renderItem={(item) => <CoverArt type="cover" coverArt={item.item.s?.id} style={nestedStyle} resizeMode='stretch' />}
+      />
+    )
+  }
+  return generator;
+}
+
+export function usePlaylistCover2x2Fetch(item: PlaylistListItem) {
+  const playlist = usePlaylistWithSongs(item.id)
+  return useMemo(() => playlist == null ? null : usePlaylistCover2x2(playlist.songs), [playlist]);
+}
+const styles = StyleSheet.create({
+  imgGrid: {
+    paddingRight: 10
+  },
+})

--- a/app/components/PlaylistCover.tsx
+++ b/app/components/PlaylistCover.tsx
@@ -1,11 +1,10 @@
-import { usePlaylistWithSongs } from '@app/hooks/music'
-import { PlaylistListItem, Song } from '@app/models/music'
+import { Song } from '@app/models/music'
 import CoverArt from '@app/components/CoverArt'
-import React, { useMemo } from 'react'
+import React from 'react'
 import { StyleSheet, ImageResizeMode, FlatList } from 'react-native'
 
-export function usePlaylistCover2x2(_songs: Song[]) {
-  const generator: React.FC<{style: any, resizeMode: ImageResizeMode}> = ({style}) => {
+export function genPlaylistCover2x2Component(_songs: Song[]) {
+  const component: React.FC<{style: any, resizeMode: ImageResizeMode}> = ({style}) => {
     const nestedStyle = { ...style, ...{ width: style.width / 2, height: style.height / 2, marginRight: 0 } }
     // we need to wrap the songs in a custom object because the list will ignore null values
     const songs = [...Array(4)].map((_, i) => ({s: i < _songs.length ? _songs[i] : null}))
@@ -19,13 +18,9 @@ export function usePlaylistCover2x2(_songs: Song[]) {
       />
     )
   }
-  return generator;
+  return React.memo(component);
 }
 
-export function usePlaylistCover2x2Fetch(item: PlaylistListItem) {
-  const playlist = usePlaylistWithSongs(item.id)
-  return useMemo(() => playlist == null ? null : usePlaylistCover2x2(playlist.songs), [playlist]);
-}
 const styles = StyleSheet.create({
   imgGrid: {
     paddingRight: 10

--- a/app/screens/LibraryPlaylists.tsx
+++ b/app/screens/LibraryPlaylists.tsx
@@ -1,16 +1,25 @@
 import GradientFlatList from '@app/components/GradientFlatList'
 import ListItem from '@app/components/ListItem'
-import { usePlaylistCover2x2Fetch } from '@app/components/PlaylistCover'
+import { genPlaylistCover2x2Component } from '@app/components/PlaylistCover'
 import { useFetchList } from '@app/hooks/list'
-import { PlaylistListItem } from '@app/models/music'
+import { PlaylistListItem, PlaylistWithSongs } from '@app/models/music'
 import { selectMusic } from '@app/state/music'
 import { useStore } from '@app/state/store'
-import React from 'react'
-import { StyleSheet } from 'react-native'
+import React, { useMemo } from 'react'
+import { ImageResizeMode, StyleSheet } from 'react-native'
 
-const PlaylistRenderItem: React.FC<{ item: PlaylistListItem }> = ({ item }) => {
-  // technically violating the hook rules but this is really a constant branching because it is server dependent
-  const CustomArt = item.coverArt != null ? null : usePlaylistCover2x2Fetch(item)
+const PlaylistRenderItem: React.FC<{ item: PlaylistListItem, getPlaylistData: (id: string) => PlaylistWithSongs | null }> = ({ item, getPlaylistData }) => {
+  let CustomArt: React.FC<{style: any, resizeMode: ImageResizeMode}> | null = null
+  if (item.coverArt == null) {
+    // some server types don't support cover art for playlists
+    // in this case we manually generate a 2x2 grid of album covers
+    // we only do so if the playlist data already exists because
+    // fetching it here will bottleneck the entire app
+    const playlist = getPlaylistData(item.id)
+    // this use of hooks is technically invalid because it is in a branch
+    // but the branch is constant for the entire lifetime of the app
+    CustomArt = useMemo(() => playlist != null ? genPlaylistCover2x2Component(playlist.songs): null, [playlist])
+  }
   return <ListItem item={item} showArt={true} showStar={false} listStyle="big" style={styles.listItem} CustomArt={CustomArt} />
 }
 
@@ -18,10 +27,12 @@ const PlaylistsList = () => {
   const fetchPlaylists = useStore(selectMusic.fetchPlaylists)
   const { list, refreshing, refresh } = useFetchList(fetchPlaylists)
 
+  const playlistFetch = useStore(store => (id: string) => id in store.playlistsWithSongs ? store.playlistsWithSongs[id] : null)
+
   return (
     <GradientFlatList
       data={list}
-      renderItem={item => <PlaylistRenderItem item={item.item} />}
+      renderItem={item => <PlaylistRenderItem item={item.item} getPlaylistData={playlistFetch} />}
       keyExtractor={item => item.id}
       onRefresh={refresh}
       refreshing={refreshing}

--- a/app/screens/LibraryPlaylists.tsx
+++ b/app/screens/LibraryPlaylists.tsx
@@ -1,5 +1,6 @@
 import GradientFlatList from '@app/components/GradientFlatList'
 import ListItem from '@app/components/ListItem'
+import { usePlaylistCover2x2Fetch } from '@app/components/PlaylistCover'
 import { useFetchList } from '@app/hooks/list'
 import { PlaylistListItem } from '@app/models/music'
 import { selectMusic } from '@app/state/music'
@@ -7,9 +8,11 @@ import { useStore } from '@app/state/store'
 import React from 'react'
 import { StyleSheet } from 'react-native'
 
-const PlaylistRenderItem: React.FC<{ item: PlaylistListItem }> = ({ item }) => (
-  <ListItem item={item} showArt={true} showStar={false} listStyle="big" style={styles.listItem} />
-)
+const PlaylistRenderItem: React.FC<{ item: PlaylistListItem }> = ({ item }) => {
+  // technically violating the hook rules but this is really a constant branching because it is server dependent
+  const CustomArt = item.coverArt != null ? null : usePlaylistCover2x2Fetch(item)
+  return <ListItem item={item} showArt={true} showStar={false} listStyle="big" style={styles.listItem} CustomArt={CustomArt} />
+}
 
 const PlaylistsList = () => {
   const fetchPlaylists = useStore(selectMusic.fetchPlaylists)
@@ -18,7 +21,7 @@ const PlaylistsList = () => {
   return (
     <GradientFlatList
       data={list}
-      renderItem={PlaylistRenderItem}
+      renderItem={item => <PlaylistRenderItem item={item.item} />}
       keyExtractor={item => item.id}
       onRefresh={refresh}
       refreshing={refreshing}

--- a/app/screens/SongListView.tsx
+++ b/app/screens/SongListView.tsx
@@ -4,7 +4,7 @@ import HeaderBar from '@app/components/HeaderBar'
 import ImageGradientFlatList from '@app/components/ImageGradientFlatList'
 import ListItem from '@app/components/ListItem'
 import ListPlayerControls from '@app/components/ListPlayerControls'
-import { usePlaylistCover2x2 } from '@app/components/PlaylistCover'
+import { genPlaylistCover2x2Component } from '@app/components/PlaylistCover'
 import { useCoverArtFile } from '@app/hooks/cache'
 import { useAlbumWithSongs, usePlaylistWithSongs } from '@app/hooks/music'
 import { AlbumWithSongs, PlaylistWithSongs, Song } from '@app/models/music'
@@ -50,9 +50,20 @@ const SongListDetails = React.memo<{
   songList?: AlbumWithSongs | PlaylistWithSongs
   subtitle?: string
 }>(({ title, songList, subtitle, type }) => {
+  // be careful that all hooks are called before the branching happens
   const coverArtFile = useCoverArtFile(songList?.coverArt, 'thumbnail')
   const [headerColor, setHeaderColor] = useState<string | undefined>(undefined)
   const setQueue = useStore(selectTrackPlayer.setQueue)
+  const coverArt = useMemo(() => {
+    if(!songList)
+      return null
+    else if(songList.coverArt != null)
+      return <CoverArt type="cover" size="original" coverArt={songList.coverArt} style={styles.cover} />
+    else {
+      const T = genPlaylistCover2x2Component(songList.songs);
+      return <T style={styles.cover} resizeMode='stretch' />
+    }
+  }, [songList])
 
   if (!songList) {
     return <SongListDetailsFallback />
@@ -74,14 +85,6 @@ const SongListDetails = React.memo<{
     }
   } else {
     typeName = 'Playlist'
-  }
-
-  let coverArt = null;
-  if (songList.coverArt != null)
-    coverArt = <CoverArt type="cover" size="original" coverArt={songList.coverArt} style={styles.cover} />;
-  else {
-    const T = useCallback(usePlaylistCover2x2(songList.songs), []);
-    coverArt = useMemo(() => <T style={styles.cover} resizeMode='stretch' />, [T]);
   }
   
   return (

--- a/app/screens/SongListView.tsx
+++ b/app/screens/SongListView.tsx
@@ -4,6 +4,7 @@ import HeaderBar from '@app/components/HeaderBar'
 import ImageGradientFlatList from '@app/components/ImageGradientFlatList'
 import ListItem from '@app/components/ListItem'
 import ListPlayerControls from '@app/components/ListPlayerControls'
+import { usePlaylistCover2x2 } from '@app/components/PlaylistCover'
 import { useCoverArtFile } from '@app/hooks/cache'
 import { useAlbumWithSongs, usePlaylistWithSongs } from '@app/hooks/music'
 import { AlbumWithSongs, PlaylistWithSongs, Song } from '@app/models/music'
@@ -11,7 +12,7 @@ import { useStore } from '@app/state/store'
 import { selectTrackPlayer } from '@app/state/trackplayer'
 import colors from '@app/styles/colors'
 import font from '@app/styles/font'
-import React, { useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
 
 type SongListType = 'album' | 'playlist'
@@ -75,6 +76,14 @@ const SongListDetails = React.memo<{
     typeName = 'Playlist'
   }
 
+  let coverArt = null;
+  if (songList.coverArt != null)
+    coverArt = <CoverArt type="cover" size="original" coverArt={songList.coverArt} style={styles.cover} />;
+  else {
+    const T = useCallback(usePlaylistCover2x2(songList.songs), []);
+    coverArt = useMemo(() => <T style={styles.cover} resizeMode='stretch' />, [T]);
+  }
+  
   return (
     <View style={styles.container}>
       <HeaderBar
@@ -103,7 +112,7 @@ const SongListDetails = React.memo<{
         contentMarginTop={26}
         ListHeaderComponent={
           <View style={styles.content}>
-            <CoverArt type="cover" size="original" coverArt={songList.coverArt} style={styles.cover} />
+            {coverArt}
             <Text style={styles.title}>{songList.name}</Text>
             {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : <></>}
             {songList.songs.length > 0 && (


### PR DESCRIPTION
Some subsonic implementations do not provide cover art images for playlists (Navidrome for example). I have added code which in this case generates a 2x2 grid image made up of the album cover art.

The main difficulty is when to get the playlist data (songs) required to do this. In my first commit I manually fetched this when browsing through the list of playlists. This made it impossible to perform user actions like selecting playlists because the response from the server for this was too delayed. So instead I switched to only showing the 2x2 grid **if** the playlist data is already present. This way there is no noticeable slow down. The downside is that the 2x2 grids only pop up after the playlist has been viewed at least once.

I think in the future it would be optimal if there was some background process which slowly prefetches playlist data (or artist or album data really) to have the best of both worlds.