### PR TITLE
Use .view method suffix to target API version 1.14.0

### DIFF
--- a/app/subsonic/api.ts
+++ b/app/subsonic/api.ts
@@ -72,7 +72,7 @@ export class SubsonicApiClient {
       this.params.append('s', server.salt)
     }
 
-    this.params.append('v', '1.15.0')
+    this.params.append('v', '1.14.0')
     this.params.append('c', 'subtracks')
   }
 
@@ -85,7 +85,8 @@ export class SubsonicApiClient {
       }
     }
 
-    return `${this.address}/rest/${method}?${query}`
+    // *.view was present on all method names in API 1.14.0 and earlier
+    return `${this.address}/rest/${method}.view?${query}`
   }
 
   private async apiGetXml(method: string, params?: { [key: string]: any }): Promise<Document> {


### PR DESCRIPTION
Adding the .view suffix should fix support for servers that expect only the older API method names from 1.14.0 and earlier.