### PR TITLE
Check if we paused on duck before playing again

### DIFF
--- a/app/playbackservice.ts
+++ b/app/playbackservice.ts
@@ -34,6 +34,12 @@ const rebuildQueue = () => {
   })
 }
 
+const setDuckPaused = (duckPaused: boolean) => {
+  unstable_batchedUpdates(() => {
+    useStore.getState().setDuckPaused(duckPaused)
+  })
+}
+
 let serviceCreated = false
 
 const createService = async () => {
@@ -81,9 +87,14 @@ const createService = async () => {
     }
 
     if (data.paused) {
-      trackPlayerCommands.enqueue(TrackPlayer.pause)
-    } else {
+      let state = useStore.getState().playerState
+      if (state === State.Playing || state === State.Buffering || state === State.Connecting) {
+        trackPlayerCommands.enqueue(TrackPlayer.pause)
+        setDuckPaused(true)
+      }
+    } else if (useStore.getState().duckPaused) {
       trackPlayerCommands.enqueue(TrackPlayer.play)
+      setDuckPaused(false)
     }
   })
 

--- a/app/state/trackplayer.ts
+++ b/app/state/trackplayer.ts
@@ -42,6 +42,9 @@ export type TrackPlayerSlice = {
   playerState: State
   setPlayerState: (playerState: State) => void
 
+  duckPaused: boolean
+  setDuckPaused: (duckPaused: boolean) => void
+
   currentTrack?: TrackExt
   currentTrackIdx?: number
   setCurrentTrackIdx: (idx?: number) => void
@@ -196,6 +199,9 @@ export const createTrackPlayerSlice = (set: SetState<Store>, get: GetState<Store
       }),
     )
   },
+
+  duckPaused: false,
+  setDuckPaused: duckPaused => set({ duckPaused }),
 
   queue: [],
   setQueue: async (songs, name, contextType, contextId, playTrack, shuffle) => {


### PR DESCRIPTION
Prevents music playing after an alarm or call ends if it wasn't paused by that alarm/call in the first place.  This fixes #32 and #33.