### PR TITLE
switch to useSafeAreaInsets().top

### DIFF
--- a/app/components/GradientScrollView.tsx
+++ b/app/components/GradientScrollView.tsx
@@ -4,6 +4,7 @@ import dimensions from '@app/styles/dimensions'
 import React, { ForwardedRef, PropsWithChildren } from 'react'
 import { ScrollView, ScrollViewProps, useWindowDimensions } from 'react-native'
 import Animated from 'react-native-reanimated'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export type GradientScrollViewProps = PropsWithChildren<
   Animated.AnimateProps<ScrollViewProps> & {
@@ -13,8 +14,9 @@ export type GradientScrollViewProps = PropsWithChildren<
 
 const GradientScrollView = React.forwardRef<ScrollView, GradientScrollViewProps>((props, ref) => {
   const layout = useWindowDimensions()
+  const paddingTop = useSafeAreaInsets().top
 
-  const minHeight = layout.height - (dimensions.top() + dimensions.bottom())
+  const minHeight = layout.height - (dimensions.header + paddingTop + dimensions.bottom())
 
   return (
     <Animated.ScrollView

--- a/app/components/HeaderBar.tsx
+++ b/app/components/HeaderBar.tsx
@@ -1,15 +1,16 @@
+import { Album, Song } from '@app/models/library'
 import colors from '@app/styles/colors'
 import dimensions from '@app/styles/dimensions'
 import font from '@app/styles/font'
 import { useNavigation } from '@react-navigation/core'
-import React, { useCallback } from 'react'
-import { View, StatusBar, Text, StyleSheet, ViewStyle } from 'react-native'
-import Animated from 'react-native-reanimated'
-import PressableOpacity from './PressableOpacity'
-import IconMat from 'react-native-vector-icons/MaterialIcons'
 import { ReactComponentLike } from 'prop-types'
+import React, { useCallback } from 'react'
+import { StyleSheet, Text, View, ViewStyle } from 'react-native'
+import Animated from 'react-native-reanimated'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import IconMat from 'react-native-vector-icons/MaterialIcons'
 import { AlbumContextPressable, NowPlayingContextPressable } from './ContextMenu'
-import { Album, Song } from '@app/models/library'
+import PressableOpacity from './PressableOpacity'
 
 export type HeaderContextItem = Song | Album
 
@@ -53,6 +54,7 @@ const HeaderBar = React.memo<{
   contextItem?: HeaderContextItem
 }>(({ title, headerStyle, HeaderCenter, contextItem }) => {
   const navigation = useNavigation()
+  const top = useSafeAreaInsets().top
 
   const back = useCallback(() => {
     navigation.goBack()
@@ -61,7 +63,7 @@ const HeaderBar = React.memo<{
   const _headerStyle = Array.isArray(headerStyle) ? headerStyle : [headerStyle]
 
   return (
-    <Animated.View style={[styles.container, ..._headerStyle]}>
+    <Animated.View style={[styles.container, { paddingTop: top, height: dimensions.header + top }, ..._headerStyle]}>
       <PressableOpacity onPress={back} style={styles.icons}>
         <IconMat name="arrow-back" color="white" size={25} />
       </PressableOpacity>
@@ -81,8 +83,6 @@ const HeaderBar = React.memo<{
 
 const styles = StyleSheet.create({
   container: {
-    height: dimensions.top(),
-    paddingTop: StatusBar.currentHeight,
     backgroundColor: colors.gradient.high,
     width: '100%',
     flexDirection: 'row',

--- a/app/components/ImageGradientScrollView.tsx
+++ b/app/components/ImageGradientScrollView.tsx
@@ -3,11 +3,13 @@ import colors from '@app/styles/colors'
 import dimensions from '@app/styles/dimensions'
 import React from 'react'
 import { ScrollView, ScrollViewProps, useWindowDimensions } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 const ImageGradientScrollView: React.FC<ScrollViewProps & ImageGradientBackgroundProps> = props => {
   const layout = useWindowDimensions()
+  const paddingTop = useSafeAreaInsets().top
 
-  const minHeight = layout.height - (dimensions.top() + dimensions.bottom())
+  const minHeight = layout.height - (dimensions.header + paddingTop + dimensions.bottom())
 
   return (
     <ScrollView

--- a/app/navigation/LibraryTopTabNavigator.tsx
+++ b/app/navigation/LibraryTopTabNavigator.tsx
@@ -6,28 +6,32 @@ import dimensions from '@app/styles/dimensions'
 import font from '@app/styles/font'
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs'
 import React from 'react'
-import { StatusBar, StyleSheet } from 'react-native'
+import { StyleSheet } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 const Tab = createMaterialTopTabNavigator()
 
-const LibraryTopTabNavigator = () => (
-  <Tab.Navigator
-    tabBarOptions={{
-      style: styles.tabBar,
-      labelStyle: styles.tablabelStyle,
-      indicatorStyle: styles.tabindicatorStyle,
-    }}
-    initialRouteName="albums">
-    <Tab.Screen name="albums" component={AlbumsTab} options={{ tabBarLabel: 'Albums' }} />
-    <Tab.Screen name="artists" component={ArtistsTab} options={{ tabBarLabel: 'Artists' }} />
-    <Tab.Screen name="playlists" component={PlaylistsTab} options={{ tabBarLabel: 'Playlists' }} />
-  </Tab.Navigator>
-)
+const LibraryTopTabNavigator = () => {
+  const marginTop = useSafeAreaInsets().top
+
+  return (
+    <Tab.Navigator
+      tabBarOptions={{
+        style: [styles.tabBar, { marginTop }],
+        labelStyle: styles.tablabelStyle,
+        indicatorStyle: styles.tabindicatorStyle,
+      }}
+      initialRouteName="albums">
+      <Tab.Screen name="albums" component={AlbumsTab} options={{ tabBarLabel: 'Albums' }} />
+      <Tab.Screen name="artists" component={ArtistsTab} options={{ tabBarLabel: 'Artists' }} />
+      <Tab.Screen name="playlists" component={PlaylistsTab} options={{ tabBarLabel: 'Playlists' }} />
+    </Tab.Navigator>
+  )
+}
 
 const styles = StyleSheet.create({
   tabBar: {
     height: dimensions.header,
-    marginTop: StatusBar.currentHeight,
     backgroundColor: colors.gradient.high,
     elevation: 0,
     justifyContent: 'center',

--- a/app/screens/Home.tsx
+++ b/app/screens/Home.tsx
@@ -12,7 +12,8 @@ import { useNavigation } from '@react-navigation/native'
 import equal from 'fast-deep-equal/es6/react'
 import produce from 'immer'
 import React, { useCallback, useState } from 'react'
-import { RefreshControl, ScrollView, StatusBar, StyleSheet, Text, View } from 'react-native'
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import create, { StateSelector } from 'zustand'
 
 const titles: { [key in GetAlbumListType]?: string } = {
@@ -111,6 +112,7 @@ const Home = () => {
   const types = useStoreDeep(store => store.settings.screens.home.listTypes)
   const fetchAlbumList = useStore(store => store.fetchAlbumList)
   const setList = useHomeStore(store => store.setList)
+  const paddingTop = useSafeAreaInsets().top
 
   const refresh = useCallback(async () => {
     setRefreshing(true)
@@ -135,13 +137,13 @@ const Home = () => {
   return (
     <GradientScrollView
       style={styles.scroll}
-      contentContainerStyle={styles.scrollContentContainer}
+      contentContainerStyle={{ paddingTop }}
       refreshControl={
         <RefreshControl
           refreshing={refreshing}
           onRefresh={refresh}
           colors={[colors.accent, colors.accentLow]}
-          progressViewOffset={StatusBar.currentHeight}
+          progressViewOffset={paddingTop}
         />
       }>
       <View style={styles.content}>
@@ -156,9 +158,6 @@ const Home = () => {
 const styles = StyleSheet.create({
   scroll: {
     flex: 1,
-  },
-  scrollContentContainer: {
-    paddingTop: StatusBar.currentHeight,
   },
   content: {
     paddingBottom: 20,

--- a/app/screens/Search.tsx
+++ b/app/screens/Search.tsx
@@ -5,7 +5,7 @@ import ListItem from '@app/components/ListItem'
 import NothingHere from '@app/components/NothingHere'
 import TextInput from '@app/components/TextInput'
 import { useActiveServerRefresh } from '@app/hooks/settings'
-import { Song, Album, Artist, SearchResults } from '@app/models/library'
+import { Album, Artist, SearchResults, Song } from '@app/models/library'
 import { useStore, useStoreDeep } from '@app/state/store'
 import colors from '@app/styles/colors'
 import font from '@app/styles/font'
@@ -17,11 +17,11 @@ import {
   ActivityIndicator,
   InteractionManager,
   ScrollView,
-  StatusBar,
   StyleSheet,
   TextInput as ReactTextInput,
   View,
 } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 const SongItem = React.memo<{ item: Song }>(({ item }) => {
   const setQueue = useStore(store => store.setQueue)
@@ -110,6 +110,7 @@ const Search = () => {
   const [text, setText] = useState('')
   const searchBarRef = useRef<ReactTextInput>(null)
   const scrollRef = useRef<ScrollView>(null)
+  const paddingTop = useSafeAreaInsets().top
 
   useFocusEffect(
     useCallback(() => {
@@ -153,7 +154,7 @@ const Search = () => {
   const resultsCount = results.albums.length + results.artists.length + results.songs.length
 
   return (
-    <GradientScrollView ref={scrollRef} style={styles.scroll} contentContainerStyle={styles.scrollContentContainer}>
+    <GradientScrollView ref={scrollRef} style={styles.scroll} contentContainerStyle={{ paddingTop }}>
       <View style={styles.content}>
         <View style={styles.inputBar}>
           <TextInput
@@ -179,9 +180,6 @@ const Search = () => {
 const styles = StyleSheet.create({
   scroll: {
     flex: 1,
-  },
-  scrollContentContainer: {
-    paddingTop: StatusBar.currentHeight,
   },
   content: {
     paddingHorizontal: 20,

--- a/app/screens/ServerView.tsx
+++ b/app/screens/ServerView.tsx
@@ -184,7 +184,7 @@ const ServerView: React.FC<{
   }
 
   return (
-    <GradientScrollView style={styles.scroll} contentContainerStyle={styles.scrollContentContainer}>
+    <GradientScrollView style={styles.scroll}>
       <View style={styles.content}>
         <Text style={styles.inputTitle}>Address</Text>
         <TextInput
@@ -258,9 +258,6 @@ const ServerView: React.FC<{
 const styles = StyleSheet.create({
   scroll: {
     flex: 1,
-  },
-  scrollContentContainer: {
-    // paddingTop: StatusBar.currentHeight,
   },
   content: {
     paddingHorizontal: 20,

--- a/app/screens/Settings.tsx
+++ b/app/screens/Settings.tsx
@@ -12,8 +12,9 @@ import colors from '@app/styles/colors'
 import font from '@app/styles/font'
 import { useNavigation } from '@react-navigation/core'
 import React, { useCallback, useState } from 'react'
-import { KeyboardTypeOptions, Linking, Modal, Pressable, StatusBar, StyleSheet, Text, View } from 'react-native'
+import { KeyboardTypeOptions, Linking, Modal, Pressable, StyleSheet, Text, View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 import { version } from '../../package.json'
 
@@ -296,8 +297,10 @@ const SettingsContent = React.memo(() => {
 })
 
 const Settings = () => {
+  const paddingTop = useSafeAreaInsets().top
+
   return (
-    <GradientScrollView style={styles.scroll} contentContainerStyle={styles.scrollContentContainer}>
+    <GradientScrollView style={styles.scroll} contentContainerStyle={{ paddingTop }}>
       <SettingsContent />
     </GradientScrollView>
   )
@@ -306,9 +309,6 @@ const Settings = () => {
 const styles = StyleSheet.create({
   scroll: {
     flex: 1,
-  },
-  scrollContentContainer: {
-    paddingTop: StatusBar.currentHeight,
   },
   content: {
     paddingHorizontal: 20,

--- a/app/styles/dimensions.ts
+++ b/app/styles/dimensions.ts
@@ -1,14 +1,10 @@
-import { StatusBar } from 'react-native'
-
 const header = 56
 const tabBar = 54
 
-const top = () => header + (StatusBar.currentHeight || 0)
 const bottom = () => tabBar
 
 export default {
   header,
   tabBar,
-  top,
   bottom,
 }


### PR DESCRIPTION
StatusBar.currentHeight seems just broken on some devices

Found another reference to this here: https://github.com/ovr/react-native-status-bar-height/issues/38

Closes #83 