### PR TITLE
improve url validation in settings

### DIFF
--- a/lib/app/pages/source_page.dart
+++ b/lib/app/pages/source_page.dart
@@ -44,10 +44,10 @@ class SourcePage extends HookConsumerWidget {
       autofillHints: const [AutofillHints.url],
       required: true,
       validator: (value, label) {
-        if (Uri.tryParse(value!)?.isAbsolute == false ||
-            !value.contains('http')) {
+        if (!value!.contains(RegExp(r'https?:\/\/'))) {
           return '$label must be a valid URL';
         }
+        return null;
       },
     );
     final username = LabeledTextField(

--- a/lib/app/pages/source_page.dart
+++ b/lib/app/pages/source_page.dart
@@ -44,10 +44,10 @@ class SourcePage extends HookConsumerWidget {
       autofillHints: const [AutofillHints.url],
       required: true,
       validator: (value, label) {
-        if (Uri.tryParse(value!) == null) {
+        if (Uri.tryParse(value!)?.isAbsolute == false ||
+            !value.contains('http')) {
           return '$label must be a valid URL';
         }
-        return null;
       },
     );
     final username = LabeledTextField(


### PR DESCRIPTION
It doesn't look to me like URI.tryParse is doing enough to verify if a URL is ok.
It might be better to just check against a regex like `https?:\/\/`
